### PR TITLE
feat：音量調整機能を無料プランでの使用可に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Diagnostics / Lint
+
+- `mcp__ide__getDiagnostics` はトークンを大量消費するため使用禁止。代わりに `flutter analyze` を Bash で実行すること。

--- a/lib/l10n/app_strings.dart
+++ b/lib/l10n/app_strings.dart
@@ -141,6 +141,11 @@ class AppStrings {
   String soundSet(String name) => _soundSetFn(name);
   final String Function(String) _soundSetFn;
   final String filePickFailed;
+  final String saveVolume;
+  final String volumeSaved;
+  final String zeroVolumeWarningTitle;
+  final String zeroVolumeWarningBody;
+  final String volumeZeroNotice;
 
   // Sound: volume info dialog
   final String volumeInfoTitle;
@@ -157,8 +162,10 @@ class AppStrings {
   String badgeUnlockCondition(int days) => _badgeUnlockConditionFn(days);
   final String Function(int) _badgeUnlockConditionFn;
   final String badgeEarnedTitle;
-  String badgeEarnedBody(String name) => _badgeEarnedBodyFn(name);
-  final String Function(String) _badgeEarnedBodyFn;
+  String badgeEarnedBody(int days) => _badgeEarnedBodyFn(days);
+  final String Function(int) _badgeEarnedBodyFn;
+  String badgeAnniversaryBody(int years) => _badgeAnniversaryBodyFn(years);
+  final String Function(int) _badgeAnniversaryBodyFn;
   String badgeShareText(String name, int streak) =>
       _badgeShareTextFn(name, streak);
   final String Function(String, int) _badgeShareTextFn;
@@ -260,6 +267,11 @@ class AppStrings {
     required this.selectFromDevice,
     required String Function(String) soundSetFn,
     required this.filePickFailed,
+    required this.saveVolume,
+    required this.volumeSaved,
+    required this.zeroVolumeWarningTitle,
+    required this.zeroVolumeWarningBody,
+    required this.volumeZeroNotice,
     required this.volumeInfoTitle,
     required this.freePlanLabel,
     required this.freePlanVolumeDesc,
@@ -270,13 +282,15 @@ class AppStrings {
     required this.badgesTitle,
     required String Function(int) badgeUnlockConditionFn,
     required this.badgeEarnedTitle,
-    required String Function(String) badgeEarnedBodyFn,
+    required String Function(int) badgeEarnedBodyFn,
+    required String Function(int) badgeAnniversaryBodyFn,
     required String Function(String, int) badgeShareTextFn,
     required String Function(String) unlockedAtFn,
     required this.selectLanguageTitle,
   })  : _badgeNames = badgeNames,
         _badgeUnlockConditionFn = badgeUnlockConditionFn,
         _badgeEarnedBodyFn = badgeEarnedBodyFn,
+        _badgeAnniversaryBodyFn = badgeAnniversaryBodyFn,
         _badgeShareTextFn = badgeShareTextFn,
         _unlockedAtFn = unlockedAtFn,
         _missionNames = missionNames,
@@ -375,7 +389,6 @@ class AppStrings {
     premiumFeatures: [
       '読書・勉強ミッション', // バーピー・読書・勉強ミッション // 新バージョンで表示変更する
       'アラーム音の選択',
-      '音量調整',
       '達成統計・連続記録',
       'SNSシェア機能',
     ],
@@ -411,6 +424,11 @@ class AppStrings {
     selectFromDevice: '端末から選択',
     soundSetFn: _jaSoundSet,
     filePickFailed: 'ファイルの選択に失敗しました',
+    saveVolume: 'この音量で保存',
+    volumeSaved: 'アラーム音量を保存しました',
+    zeroVolumeWarningTitle: '音量がゼロです',
+    zeroVolumeWarningBody: 'アラームの音が鳴りません。このまま保存しますか？',
+    volumeZeroNotice: '音量ゼロ：アラーム音が鳴りません',
     volumeInfoTitle: 'アラーム音量について',
     freePlanLabel: '無料プラン',
     freePlanVolumeDesc: 'アラームは常に最大音量で鳴ります。確実に起きるための仕様です。',
@@ -418,16 +436,42 @@ class AppStrings {
     premiumPlanVolumeDesc: 'お好みの音量に調整できます。設定した音量でアラームが鳴ります。',
     volumePreviewNote: '※ 試聴はデバイスの現在の音量で再生されます。',
     badgeNames: {
-      'sprout': '芽生え',
-      'startDash': 'スタートダッシュ',
-      'routine': 'ルーティン',
-      'master': 'マスター',
-      'legend': 'レジェンド',
+      'day1': 'はじめの一歩',
+      'day3': '芽生え',
+      'day7': 'スタートダッシュ',
+      'day14': 'ルーティン',
+      'day21': '習慣化',
+      'day28': '4週間達成',
+      'day30': '1ヶ月達成',
+      'day40': '加速',
+      'day50': 'マスター',
+      'day60': '情熱',
+      'day70': '鉄壁',
+      'day80': 'ロケット',
+      'day90': '3ヶ月達成',
+      'day100': 'レジェンド',
+      'day125': 'きらめき',
+      'day150': '栄光',
+      'day175': '閃光',
+      'day200': '200日の軌跡',
+      'day300': '城塞',
+      'day365': '1年達成',
+      'day400': 'グローバル',
+      'day500': '大地',
+      'day600': 'フレア',
+      'day700': '夜明け',
+      'day730': '2年達成',
+      'day800': 'サイクロン',
+      'day900': '火山',
+      'day1000': '無限',
+      'day1095': '3年達成',
+      'day1100': '輝き',
     },
     badgesTitle: '達成バッジ',
     badgeUnlockConditionFn: _jaBadgeUnlockCondition,
     badgeEarnedTitle: 'おめでとう！',
     badgeEarnedBodyFn: _jaBadgeEarnedBody,
+    badgeAnniversaryBodyFn: _jaBadgeAnniversaryBody,
     badgeShareTextFn: _jaBadgeShareText,
     unlockedAtFn: _jaUnlockedAt,
     selectLanguageTitle: '言語を選択 / Select Language',
@@ -515,7 +559,6 @@ class AppStrings {
     premiumFeatures: [
       'Reading & Study missions', // Burpees, Reading & Study missions // 新バージョンで表示変更する
       'Alarm sound selection',
-      'Volume control',
       'Achievement stats & streaks',
       'Social sharing',
     ],
@@ -551,6 +594,11 @@ class AppStrings {
     selectFromDevice: 'Select from Device',
     soundSetFn: _enSoundSet,
     filePickFailed: 'Failed to select file',
+    saveVolume: 'Save Volume',
+    volumeSaved: 'Alarm volume saved',
+    zeroVolumeWarningTitle: 'Volume is zero',
+    zeroVolumeWarningBody: 'The alarm will not make any sound. Save anyway?',
+    volumeZeroNotice: 'Volume is zero: alarm will be silent',
     volumeInfoTitle: 'About Alarm Volume',
     freePlanLabel: 'Free Plan',
     freePlanVolumeDesc:
@@ -560,16 +608,42 @@ class AppStrings {
         'Adjust the volume to your preference. The alarm plays at your set volume.',
     volumePreviewNote: '* Preview plays at your current device volume.',
     badgeNames: {
-      'sprout': 'Sprout',
-      'startDash': 'Start Dash',
-      'routine': 'Routine',
-      'master': 'Master',
-      'legend': 'Legend',
+      'day1': 'First Step',
+      'day3': 'Sprout',
+      'day7': 'Start Dash',
+      'day14': 'Routine',
+      'day21': 'Habit Formed',
+      'day28': '4 Weeks',
+      'day30': '1 Month',
+      'day40': 'Accelerate',
+      'day50': 'Master',
+      'day60': 'Passion',
+      'day70': 'Iron Wall',
+      'day80': 'Rocket',
+      'day90': '3 Months',
+      'day100': 'Legend',
+      'day125': 'Sparkle',
+      'day150': 'Glory',
+      'day175': 'Flash',
+      'day200': '200-Day Journey',
+      'day300': 'Fortress',
+      'day365': '1 Year',
+      'day400': 'Global',
+      'day500': 'Terrain',
+      'day600': 'Flare',
+      'day700': 'Daybreak',
+      'day730': '2 Years',
+      'day800': 'Cyclone',
+      'day900': 'Volcano',
+      'day1000': 'Infinity',
+      'day1095': '3 Years',
+      'day1100': 'Radiance',
     },
     badgesTitle: 'Achievement Badges',
     badgeUnlockConditionFn: _enBadgeUnlockCondition,
     badgeEarnedTitle: 'Congratulations!',
     badgeEarnedBodyFn: _enBadgeEarnedBody,
+    badgeAnniversaryBodyFn: _enBadgeAnniversaryBody,
     badgeShareTextFn: _enBadgeShareText,
     unlockedAtFn: _enUnlockedAt,
     selectLanguageTitle: '言語を選択 / Select Language',
@@ -590,7 +664,8 @@ class AppStrings {
   static String _jaTimes(int n) => '$n回';
   static String _jaSoundSet(String name) => '$name を設定しました';
   static String _jaBadgeUnlockCondition(int days) => '$days日連続で解放';
-  static String _jaBadgeEarnedBody(String name) => '「$name」バッジを獲得しました！';
+  static String _jaBadgeEarnedBody(int days) => '$days日連続達成しました！';
+  static String _jaBadgeAnniversaryBody(int years) => '$years年達成しました！';
   static String _jaBadgeShareText(String name, int streak) =>
       'モーニングルーティン強制アラームで「$name」バッジを獲得！$streak日連続起床達成！';
   static String _jaUnlockedAt(String date) => '$date 獲得';
@@ -613,8 +688,10 @@ class AppStrings {
   static String _enSoundSet(String name) => '$name has been set';
   static String _enBadgeUnlockCondition(int days) =>
       'Unlocks at $days-day streak';
-  static String _enBadgeEarnedBody(String name) =>
-      'You earned the "$name" badge!';
+  static String _enBadgeEarnedBody(int days) =>
+      'You achieved a $days-day streak!';
+  static String _enBadgeAnniversaryBody(int years) =>
+      'You achieved $years year${years > 1 ? 's' : ''}!';
   static String _enBadgeShareText(String name, int streak) =>
       'I earned the "$name" badge on ForcedWake Alarm! $streak-day streak!';
   static String _enUnlockedAt(String date) => 'Earned $date';

--- a/lib/models/alarm_settings.dart
+++ b/lib/models/alarm_settings.dart
@@ -18,7 +18,7 @@ class AlarmSettings {
     this.isEnabled = true,
     int? targetCount,
     this.alarmSoundId = 'fanfare',
-    this.alarmVolume = 1.0,
+    this.alarmVolume = 0.5,
     this.customSoundPath,
     this.customSoundName,
   }) : targetCount =
@@ -69,7 +69,7 @@ class AlarmSettings {
       isEnabled: json['isEnabled'] ?? true,
       targetCount: json['targetCount'],
       alarmSoundId: (json['alarmSoundId'] as String?) ?? 'fanfare',
-      alarmVolume: (json['alarmVolume'] ?? 1.0).toDouble(),
+      alarmVolume: (json['alarmVolume'] ?? 0.5).toDouble(),
       customSoundPath: json['customSoundPath'] as String?,
       customSoundName: json['customSoundName'] as String?,
     );

--- a/lib/models/badge_type.dart
+++ b/lib/models/badge_type.dart
@@ -1,35 +1,192 @@
 import 'package:flutter/material.dart';
 
 enum BadgeType {
-  sprout(
+  day1(
+    requiredStreak: 1,
+    icon: Icons.emoji_events,
+    color: Colors.green,
+    gradientColors: [Color(0xFF4CAF50), Color(0xFF81C784)],
+  ),
+  day3(
     requiredStreak: 3,
     icon: Icons.park,
     color: Colors.green,
     gradientColors: [Color(0xFF4CAF50), Color(0xFF81C784)],
   ),
-  startDash(
+  day7(
     requiredStreak: 7,
     icon: Icons.local_fire_department,
     color: Colors.orange,
     gradientColors: [Color(0xFFFF9800), Color(0xFFFFB74D)],
   ),
-  routine(
+  day14(
     requiredStreak: 14,
     icon: Icons.star,
     color: Colors.amber,
     gradientColors: [Color(0xFFFFC107), Color(0xFFFFD54F)],
   ),
-  master(
+  day21(
+    requiredStreak: 21,
+    icon: Icons.trending_up,
+    color: Colors.teal,
+    gradientColors: [Color(0xFF009688), Color(0xFF4DB6AC)],
+  ),
+  day28(
+    requiredStreak: 28,
+    icon: Icons.calendar_month,
+    color: Colors.cyan,
+    gradientColors: [Color(0xFF00BCD4), Color(0xFF4DD0E1)],
+  ),
+  day30(
+    requiredStreak: 30,
+    icon: Icons.looks_one,
+    color: Colors.indigo,
+    gradientColors: [Color(0xFF3F51B5), Color(0xFF7986CB)],
+  ),
+  day40(
+    requiredStreak: 40,
+    icon: Icons.bolt,
+    color: Colors.deepOrange,
+    gradientColors: [Color(0xFFFF5722), Color(0xFFFF8A65)],
+  ),
+  day50(
     requiredStreak: 50,
     icon: Icons.diamond,
     color: Colors.blue,
     gradientColors: [Color(0xFF2196F3), Color(0xFF64B5F6)],
   ),
-  legend(
+  day60(
+    requiredStreak: 60,
+    icon: Icons.whatshot,
+    color: Colors.red,
+    gradientColors: [Color(0xFFF44336), Color(0xFFEF5350)],
+  ),
+  day70(
+    requiredStreak: 70,
+    icon: Icons.shield,
+    color: Colors.brown,
+    gradientColors: [Color(0xFF795548), Color(0xFFA1887F)],
+  ),
+  day80(
+    requiredStreak: 80,
+    icon: Icons.rocket_launch,
+    color: Colors.pink,
+    gradientColors: [Color(0xFFE91E63), Color(0xFFF06292)],
+  ),
+  day90(
+    requiredStreak: 90,
+    icon: Icons.military_tech,
+    color: Colors.deepPurple,
+    gradientColors: [Color(0xFF673AB7), Color(0xFF9575CD)],
+  ),
+  day100(
     requiredStreak: 100,
     icon: Icons.workspace_premium,
     color: Colors.purple,
     gradientColors: [Color(0xFF9C27B0), Color(0xFFFFD700)],
+  ),
+  day125(
+    requiredStreak: 125,
+    icon: Icons.auto_awesome,
+    color: Colors.lime,
+    gradientColors: [Color(0xFFCDDC39), Color(0xFFDCE775)],
+  ),
+  day150(
+    requiredStreak: 150,
+    icon: Icons.grade,
+    color: Colors.amber,
+    gradientColors: [Color(0xFFFFC107), Color(0xFFFFD54F)],
+  ),
+  day175(
+    requiredStreak: 175,
+    icon: Icons.flash_on,
+    color: Colors.yellow,
+    gradientColors: [Color(0xFFFFEB3B), Color(0xFFFFF176)],
+  ),
+  day200(
+    requiredStreak: 200,
+    icon: Icons.emoji_events,
+    color: Color(0xFFFFD700),
+    gradientColors: [Color(0xFFFFD700), Color(0xFFFFF8E1)],
+  ),
+  day300(
+    requiredStreak: 300,
+    icon: Icons.castle,
+    color: Colors.blueGrey,
+    gradientColors: [Color(0xFF607D8B), Color(0xFF90A4AE)],
+  ),
+  day365(
+    requiredStreak: 365,
+    icon: Icons.cake,
+    color: Colors.red,
+    gradientColors: [Color(0xFFF44336), Color(0xFFFFD700)],
+  ),
+  day400(
+    requiredStreak: 400,
+    icon: Icons.public,
+    color: Colors.lightBlue,
+    gradientColors: [Color(0xFF03A9F4), Color(0xFF4FC3F7)],
+  ),
+  day500(
+    requiredStreak: 500,
+    icon: Icons.landscape,
+    color: Colors.green,
+    gradientColors: [Color(0xFF4CAF50), Color(0xFF81C784)],
+  ),
+  day600(
+    requiredStreak: 600,
+    icon: Icons.flare,
+    color: Colors.orange,
+    gradientColors: [Color(0xFFFF9800), Color(0xFFFFB74D)],
+  ),
+  day700(
+    requiredStreak: 700,
+    icon: Icons.nightlight,
+    color: Colors.indigo,
+    gradientColors: [Color(0xFF3F51B5), Color(0xFF7986CB)],
+  ),
+  day730(
+    requiredStreak: 730,
+    icon: Icons.celebration,
+    color: Colors.purple,
+    gradientColors: [Color(0xFF9C27B0), Color(0xFFFFD700)],
+  ),
+  day800(
+    requiredStreak: 800,
+    icon: Icons.cyclone,
+    color: Colors.teal,
+    gradientColors: [Color(0xFF009688), Color(0xFF4DB6AC)],
+  ),
+  day900(
+    requiredStreak: 900,
+    icon: Icons.volcano,
+    color: Colors.deepOrange,
+    gradientColors: [Color(0xFFFF5722), Color(0xFFFF8A65)],
+  ),
+  day1000(
+    requiredStreak: 1000,
+    icon: Icons.all_inclusive,
+    color: Color(0xFFFFD700),
+    gradientColors: [Color(0xFFFFD700), Color(0xFFFFF8E1)],
+  ),
+  day1095(
+    requiredStreak: 1095,
+    icon: Icons.stars,
+    color: Colors.purple,
+    gradientColors: [
+      Color(0xFFFF0000),
+      Color(0xFFFF9800),
+      Color(0xFFFFEB3B),
+      Color(0xFF4CAF50),
+      Color(0xFF2196F3),
+      Color(0xFF9C27B0),
+    ],
+  ),
+  day1100(
+    requiredStreak: 1100,
+    icon: Icons.brightness_7,
+    color: Colors.white,
+    gradientColors: [Color(0xFFFFFFFF), Color(0xFFFFD700)],
   );
 
   final int requiredStreak;

--- a/lib/screens/alarm_screen.dart
+++ b/lib/screens/alarm_screen.dart
@@ -7,7 +7,6 @@ import '../services/audio_service.dart';
 import '../services/statistics_service.dart';
 import '../state/alarm_state.dart';
 import '../state/language_state.dart';
-import '../state/premium_state.dart';
 import '../theme/app_colors.dart';
 
 class AlarmScreen extends StatefulWidget {
@@ -23,7 +22,6 @@ class _AlarmScreenState extends State<AlarmScreen>
     with SingleTickerProviderStateMixin {
   final AudioService _audioService = AudioService();
   Timer? _autoStopTimer;
-  StreamSubscription<double>? _volumeSubscription;
   late AnimationController _pulseController;
   late Animation<double> _pulseAnimation;
 
@@ -41,21 +39,16 @@ class _AlarmScreenState extends State<AlarmScreen>
     );
 
     final settings = context.read<AlarmState>().settings;
-    final isPremium = context.read<PremiumState>().isPremium;
-    final alarmVolume = isPremium ? settings.alarmVolume : 1.0;
+    final alarmVolume = settings.alarmVolume;
     _audioService.playAlarm(
       soundId: settings.alarmSoundId,
       volume: alarmVolume,
       customSoundPath: settings.customSoundPath,
     );
 
-    // Prevent volume changes during alarm
-    VolumeController().showSystemUI = false;
-    _volumeSubscription = VolumeController().listener((volume) {
-      if (volume < alarmVolume - 0.01) {
-        VolumeController().setVolume(alarmVolume);
-      }
-    });
+    // Set device volume to saved alarm volume
+    VolumeController().showSystemUI = true;
+    VolumeController().setVolume(alarmVolume);
 
     // 10 minute auto-stop
     _autoStopTimer = Timer(const Duration(minutes: 10), () {
@@ -68,8 +61,6 @@ class _AlarmScreenState extends State<AlarmScreen>
 
   @override
   void dispose() {
-    _volumeSubscription?.cancel();
-    _volumeSubscription = null;
     _autoStopTimer?.cancel();
     _pulseController.dispose();
     _audioService.dispose();
@@ -137,8 +128,6 @@ class _AlarmScreenState extends State<AlarmScreen>
                   height: 60,
                   child: ElevatedButton(
                     onPressed: () {
-                      _volumeSubscription?.cancel();
-                      _volumeSubscription = null;
                       Navigator.pushReplacementNamed(context, '/exercise');
                     },
                     style: ElevatedButton.styleFrom(

--- a/lib/screens/exercise_screen.dart
+++ b/lib/screens/exercise_screen.dart
@@ -14,7 +14,6 @@ import '../services/image_labeling_service.dart';
 import '../services/text_recognition_service.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 import '../state/alarm_state.dart';
-import '../state/premium_state.dart';
 import '../utils/camera_helper.dart';
 import '../utils/exercise_detector.dart';
 import '../utils/study_detector.dart';
@@ -91,8 +90,7 @@ class _ExerciseScreenState extends State<ExerciseScreen> {
     }
 
     final settings = alarmState.settings;
-    final isPremium = context.read<PremiumState>().isPremium;
-    final alarmVolume = isPremium ? settings.alarmVolume : 1.0;
+    final alarmVolume = settings.alarmVolume;
     _audioService.playAlarm(
       soundId: settings.alarmSoundId,
       volume: alarmVolume,

--- a/lib/screens/sound_selection_screen.dart
+++ b/lib/screens/sound_selection_screen.dart
@@ -8,6 +8,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:volume_controller/volume_controller.dart';
 import '../models/alarm_sound.dart';
+import '../l10n/app_strings.dart';
 import '../state/alarm_state.dart';
 import '../state/language_state.dart';
 import '../state/premium_state.dart';
@@ -24,8 +25,8 @@ class _SoundSelectionScreenState extends State<SoundSelectionScreen>
     with WidgetsBindingObserver {
   final AudioPlayer _previewPlayer = AudioPlayer();
   String? _playingId;
-  double _deviceVolume = 1.0;
-  StreamSubscription<double>? _volumeSubscription;
+  double _sliderVolume = 0.5;
+  double _savedVolume = 0.5;
   bool _isPickingFile = false;
 
   @override
@@ -38,22 +39,11 @@ class _SoundSelectionScreenState extends State<SoundSelectionScreen>
   Future<void> _initVolumeListener() async {
     try {
       VolumeController().showSystemUI = true;
-      final vol = await VolumeController().getVolume();
+      final saved = context.read<AlarmState>().settings.alarmVolume;
       if (mounted) {
-        setState(() => _deviceVolume = vol.clamp(0.0, 1.0));
-      }
-
-      if (!mounted) return;
-      final isPremium = context.read<PremiumState>().isPremium;
-      if (isPremium) {
-        // Premium: sync slider with device volume buttons
-        _volumeSubscription = VolumeController().listener((volume) {
-          if (mounted) {
-            setState(() => _deviceVolume = volume.clamp(0.0, 1.0));
-            context
-                .read<AlarmState>()
-                .updateAlarmVolume(volume.clamp(0.3, 1.0));
-          }
+        setState(() {
+          _sliderVolume = saved.clamp(0.0, 1.0);
+          _savedVolume = saved.clamp(0.0, 1.0);
         });
       }
     } catch (_) {}
@@ -77,7 +67,6 @@ class _SoundSelectionScreenState extends State<SoundSelectionScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _volumeSubscription?.cancel();
     _previewPlayer.dispose();
     super.dispose();
   }
@@ -89,7 +78,9 @@ class _SoundSelectionScreenState extends State<SoundSelectionScreen>
 
   Future<void> _startPreview(String id) async {
     setState(() => _playingId = id);
-    await _previewPlayer.setVolume(_deviceVolume);
+    // Set device volume to match slider for preview
+    VolumeController().setVolume(_sliderVolume.clamp(0.0, 1.0));
+    await _previewPlayer.setVolume(1.0);
     await _previewPlayer.setLoopMode(LoopMode.one);
     await _previewPlayer.seek(Duration.zero);
     unawaited(_previewPlayer.play());
@@ -188,10 +179,68 @@ class _SoundSelectionScreenState extends State<SoundSelectionScreen>
   }
 
   void _onVolumeChanged(double value) {
-    setState(() => _deviceVolume = value);
-    VolumeController().setVolume(value);
-    context.read<AlarmState>().updateAlarmVolume(value.clamp(0.3, 1.0));
+    setState(() => _sliderVolume = value);
+    // Update device volume only while previewing
+    if (_playingId != null) {
+      VolumeController().setVolume(value.clamp(0.0, 1.0));
+    }
   }
+
+  void _saveVolume() {
+    final s = context.read<LanguageState>().strings;
+    if (_sliderVolume < 0.01) {
+      _showZeroVolumeWarning();
+      return;
+    }
+    _doSaveVolume(s);
+  }
+
+  void _doSaveVolume(AppStrings s) {
+    context.read<AlarmState>().updateAlarmVolume(_sliderVolume.clamp(0.0, 1.0));
+    setState(() => _savedVolume = _sliderVolume);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(s.volumeSaved)),
+    );
+  }
+
+  void _showZeroVolumeWarning() {
+    final s = context.read<LanguageState>().strings;
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: Text(
+          s.zeroVolumeWarningTitle,
+          style: const TextStyle(color: AppColors.textPrimary, fontSize: 18),
+        ),
+        content: Text(
+          s.zeroVolumeWarningBody,
+          style: const TextStyle(color: AppColors.textSecondary, fontSize: 14),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(s.cancel,
+                style: const TextStyle(color: AppColors.textSecondary)),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(ctx);
+              _doSaveVolume(s);
+            },
+            child: Text(s.saveVolume,
+                style: const TextStyle(color: Colors.redAccent)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool get _hasVolumeChanged =>
+      (_sliderVolume - _savedVolume).abs() > 0.001;
 
   void _showVolumeInfo() {
     final s = context.read<LanguageState>().strings;
@@ -301,76 +350,68 @@ class _SoundSelectionScreenState extends State<SoundSelectionScreen>
                       child: const Icon(Icons.info_outline,
                           color: AppColors.textHint, size: 18),
                     ),
-                    if (!isPremium) ...[
+                    if (_savedVolume < 0.01) ...[
                       const SizedBox(width: 8),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 2),
-                        decoration: BoxDecoration(
-                          color: AppColors.accent,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: const Text(
-                          'Premium',
-                          style: TextStyle(
-                            color: AppColors.gold,
-                            fontSize: 10,
-                            fontWeight: FontWeight.w900,
+                      Flexible(
+                        child: Text(
+                          s.volumeZeroNotice,
+                          style: const TextStyle(
+                            color: Colors.redAccent,
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
                           ),
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                     ],
                   ],
                 ),
                 const SizedBox(height: 8),
-                if (isPremium) ...[
-                  Slider(
-                    value: _deviceVolume.clamp(0.0, 1.0),
-                    min: 0.0,
-                    max: 1.0,
-                    activeColor: AppColors.accent,
-                    inactiveColor: AppColors.textHint,
-                    onChanged: _onVolumeChanged,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(s.volumeMin,
-                          style:
-                              const TextStyle(color: AppColors.textSecondary)),
-                      Text(s.volumeMax,
-                          style:
-                              const TextStyle(color: AppColors.textSecondary)),
-                    ],
-                  ),
-                ] else ...[
-                  // Free plan: show max volume indicator
-                  const Slider(
-                    value: 1.0,
-                    min: 0.0,
-                    max: 1.0,
-                    activeColor: AppColors.textHint,
-                    inactiveColor: AppColors.textHint,
-                    onChanged: null,
-                  ),
-                  RichText(
-                    text: TextSpan(
-                      style: const TextStyle(
-                          color: AppColors.textHint, fontSize: 12),
-                      children: [
-                        TextSpan(text: s.alarmAtMaxVolumePrefix),
-                        TextSpan(
-                          text: s.alarmAtMaxVolumeHighlight,
-                          style: const TextStyle(
-                            color: Colors.redAccent,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        TextSpan(text: s.alarmAtMaxVolumeSuffix),
-                      ],
+                Slider(
+                  value: _sliderVolume.clamp(0.0, 1.0),
+                  min: 0.0,
+                  max: 1.0,
+                  activeColor: AppColors.accent,
+                  inactiveColor: AppColors.textHint,
+                  onChanged: _onVolumeChanged,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(s.volumeMin,
+                        style:
+                            const TextStyle(color: AppColors.textSecondary)),
+                    Text(s.volumeMax,
+                        style:
+                            const TextStyle(color: AppColors.textSecondary)),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _hasVolumeChanged ? _saveVolume : null,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.accent,
+                      disabledBackgroundColor:
+                          AppColors.accent.withOpacity(0.3),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                    ),
+                    child: Text(
+                      s.saveVolume,
+                      style: TextStyle(
+                        color: _hasVolumeChanged
+                            ? AppColors.surface
+                            : AppColors.surface.withOpacity(0.5),
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
-                ],
+                ),
               ],
             ),
           ),

--- a/lib/state/alarm_state.dart
+++ b/lib/state/alarm_state.dart
@@ -63,7 +63,7 @@ class AlarmState extends ChangeNotifier {
   }
 
   Future<void> updateAlarmVolume(double volume) async {
-    _settings = _settings.copyWith(alarmVolume: volume.clamp(0.3, 1.0));
+    _settings = _settings.copyWith(alarmVolume: volume.clamp(0.0, 1.0));
     await _storageService.saveAlarmSettings(_settings);
     notifyListeners();
   }

--- a/lib/widgets/badge_earned_dialog.dart
+++ b/lib/widgets/badge_earned_dialog.dart
@@ -17,9 +17,16 @@ class BadgeEarnedDialog extends StatelessWidget {
     required this.strings,
   });
 
+  static const _anniversaryDays = {365: 1, 730: 2, 1095: 3};
+
   @override
   Widget build(BuildContext context) {
     final name = strings.badgeName(badge.name);
+    final days = badge.requiredStreak;
+    final anniversaryYears = _anniversaryDays[days];
+    final bodyText = anniversaryYears != null
+        ? strings.badgeAnniversaryBody(anniversaryYears)
+        : strings.badgeEarnedBody(days);
 
     return Dialog(
       backgroundColor: AppColors.surface,
@@ -50,7 +57,7 @@ class BadgeEarnedDialog extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             Text(
-              strings.badgeEarnedBody(name),
+              bodyText,
               textAlign: TextAlign.center,
               style: const TextStyle(
                 color: AppColors.textSecondary,


### PR DESCRIPTION
## 概要
音量調節機能を無料プラン化

## 変更内容
- 音量調整機能を有料▶無料プラン化
- 音量を保存する機能を実装
- デフォルト音量を1.0▶0.5に変更
- 音量0で警告メッセージ表示
- （その他）継続バッジを5▶30個に変更